### PR TITLE
Quote gi_list when testing

### DIFF
--- a/functions/__gi_update_completions.fish
+++ b/functions/__gi_update_completions.fish
@@ -4,7 +4,7 @@ function __gi_update_completions -d "Update completions for gitignore.io"
 
   # Download list of ignore types
   set -l gi_list (gi list | tr ',' ' ')
-  if test -z $gi_list
+  if test -z "$gi_list"
     echo "No result returned from gitignore.io" >&2
     return 1
   end


### PR DESCRIPTION
Unquoted, test throws an error because it recives multiple arguments:

```
$ test -z foo bar
test: unexpected argument at index 2: 'bar'
```
