### PR TITLE
Quote entire complete command

### DIFF
--- a/functions/__gi_update_completions.fish
+++ b/functions/__gi_update_completions.fish
@@ -17,5 +17,5 @@ function __gi_update_completions -d "Update completions for gitignore.io"
   end
 
   # Output new completions
-  echo complete -c gi -a \"update-completions $gi_list\" >$compl_file
+  echo "complete -c gi -a \"update-completions $gi_list\"" >$compl_file
 end


### PR DESCRIPTION
Fixes issues generating the complete command where quote marks appear
in multiple places (only the escaped quotes) and ensures the list of
arguments to -a are correctly quoted.
