### PR TITLE
Update API URL

### DIFF
--- a/functions/gi.fish
+++ b/functions/gi.fish
@@ -5,5 +5,5 @@ function gi -d "gitignore.io cli for fish"
   end
 
   set -l params (echo $argv|tr ' ' ',')
-  curl -s https://www.gitignore.io/api/$params
+  curl --silent --location https://www.toptal.com/developers/gitignore/api/$params
 end


### PR DESCRIPTION
It looks like Toptal manage gitignore.io under their own banner now.
This broke the plugin, because `curl` wasn't passed a flag to follow
redirects.

This PR adds support for following server redirects, and updates the API URL to the new location.