### PR TITLE
gitignore.io moved to toptal.com so follow links

### DIFF
--- a/functions/gi.fish
+++ b/functions/gi.fish
@@ -5,5 +5,5 @@ function gi -d "gitignore.io cli for fish"
   end
 
   set -l params (echo $argv|tr ' ' ',')
-  curl -s https://www.gitignore.io/api/$params
+  curl -sL https://www.gitignore.io/api/$params
 end


### PR DESCRIPTION
Adding -L flag takes this plugin back to life!!!