### PR TITLE
follow redirects

### DIFF
--- a/functions/gi.fish
+++ b/functions/gi.fish
@@ -5,5 +5,5 @@ function gi -d "gitignore.io cli for fish"
   end
 
   set -l params (echo $argv|tr ' ' ',')
-  curl -s https://www.gitignore.io/api/$params
+  curl --silent --location https://www.gitignore.io/api/$params
 end


### PR DESCRIPTION
Apparently, gitignore.io now redirects to toptal.com. 

```shell
curl -I -s https://www.gitignore.io/api/terraform                                  3.556s (fix/follow-redirects) 22:54
HTTP/2 301
date: Fri, 22 Apr 2022 21:54:35 GMT
location: https://www.toptal.com/developers/gitignore/api/terraform
```

So this command return empty,
 
```shell
curl -s https://www.gitignore.io/api/terraform
```

However, this does the job

```shell
curl --location --silent https://www.gitignore.io/api/terraform

# Created by https://www.toptal.com/developers/gitignore/api/terraform
# Edit at https://www.toptal.com/developers/gitignore?templates=terraform

### Terraform ###
.
.
.
````